### PR TITLE
feat: add point and ranking to profile response

### DIFF
--- a/src/main/java/B1ND/linkUp/domain/auth/repository/UserRepository.java
+++ b/src/main/java/B1ND/linkUp/domain/auth/repository/UserRepository.java
@@ -4,11 +4,12 @@ import B1ND.linkUp.domain.auth.entity.User;
 import B1ND.linkUp.domain.ranking.dto.response.GetRankingResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, String> {
 
     Optional<User> findByEmail(String email);
 
@@ -20,4 +21,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "ORDER BY u.point DESC " +
             "LIMIT 30")
     List<GetRankingResponse> findAllByRanking();
+
+    @Query(nativeQuery = true,
+            value = "SELECT u.username AS username, u.point AS point, DENSE_RANK() OVER (ORDER BY u.point DESC) AS ranking " +
+                    "FROM `users` u " +
+                    "WHERE u.email = :email")
+    GetRankingResponse findMyRanking(@Param("email") String email);
 }

--- a/src/main/java/B1ND/linkUp/domain/profile/dto/response/ProfileResponse.java
+++ b/src/main/java/B1ND/linkUp/domain/profile/dto/response/ProfileResponse.java
@@ -1,12 +1,9 @@
 package B1ND.linkUp.domain.profile.dto.response;
 
-import B1ND.linkUp.domain.auth.entity.User;
-
 public record ProfileResponse(
         String username,
-        String email
+        String email,
+        int point,
+        long ranking
 ) {
-    public static ProfileResponse of(User user) {
-        return new ProfileResponse(user.getUsername(), user.getEmail());
-    }
 }

--- a/src/main/java/B1ND/linkUp/domain/profile/service/ProfileService.java
+++ b/src/main/java/B1ND/linkUp/domain/profile/service/ProfileService.java
@@ -1,6 +1,7 @@
 package B1ND.linkUp.domain.profile.service;
 
 import B1ND.linkUp.domain.auth.entity.User;
+import B1ND.linkUp.domain.auth.repository.UserRepository;
 import B1ND.linkUp.domain.post.entity.Posts;
 import B1ND.linkUp.domain.post.entity.PostsComment;
 import B1ND.linkUp.domain.post.repository.PostsCommentRepository;
@@ -8,6 +9,7 @@ import B1ND.linkUp.domain.post.repository.PostsRepository;
 import B1ND.linkUp.domain.profile.dto.response.MyAnswerItemResponse;
 import B1ND.linkUp.domain.profile.dto.response.MyQuestionItemResponse;
 import B1ND.linkUp.domain.profile.dto.response.ProfileResponse;
+import B1ND.linkUp.domain.ranking.dto.response.GetRankingResponse;
 import B1ND.linkUp.global.common.APIResponse;
 import B1ND.linkUp.global.common.PageResponse;
 import B1ND.linkUp.global.util.SecurityUtil;
@@ -24,12 +26,23 @@ import java.util.List;
 public class ProfileService {
 
     private final SecurityUtil securityUtil;
+    private final UserRepository userRepository;
     private final PostsRepository postsRepository;
     private final PostsCommentRepository postsCommentRepository;
 
     public APIResponse<ProfileResponse> getProfile() {
         User user = securityUtil.getUser();
-        return APIResponse.ok(ProfileResponse.of(user));
+
+        GetRankingResponse my = userRepository.findMyRanking(user.getEmail());
+
+        ProfileResponse response = new ProfileResponse(
+                user.getUsername(),
+                user.getEmail(),
+                user.getPoint(),
+                my.ranking()
+        );
+
+        return APIResponse.ok(response);
     }
 
     public APIResponse<PageResponse<MyQuestionItemResponse>> getMyQuestions(int page) {


### PR DESCRIPTION
### Task
- `/profile` 응답에 사용자 `point`, `ranking` 필드 추가
- 기존 랭킹 계산 로직(`DENSE_RANK`)을 재사용하여 프로필 랭킹 일관성 유지
- Profile DTO 및 Service 로직 수정

### ETC
- /ranking API와 동일한 기준의 랭킹을 사용하도록 Repository 쿼리 추가
- 랭킹 계산 로직 중복 없이 DB 윈도우 함수 기반으로 처리