### PR TITLE
refactor: Posts Content의 속성을 text로 변경 및 ErrorCode의 잘못된 메세지 수정

### DIFF
--- a/src/main/java/B1ND/linkUp/domain/post/entity/Posts.java
+++ b/src/main/java/B1ND/linkUp/domain/post/entity/Posts.java
@@ -2,20 +2,11 @@ package B1ND.linkUp.domain.post.entity;
 
 import B1ND.linkUp.domain.auth.entity.User;
 import B1ND.linkUp.domain.post.dto.request.UpdatePostsRequest;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.sql.Update;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -31,6 +22,7 @@ public class Posts {
     private Long id;
 
     private String title;
+    @Column(columnDefinition = "TEXT")
     private String content;
     private String author;
     private Category category;

--- a/src/main/java/B1ND/linkUp/global/exception/ErrorCode.java
+++ b/src/main/java/B1ND/linkUp/global/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
 
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_001", "이메일 또는 비밀번호가 올바르지 않습니다."),
     EMAIL_ALREADY_USED(HttpStatus.CONFLICT, "AUTH_002", "이미 사용 중인 이메일입니다."),
-    USERNAME_ALREADY_USED(HttpStatus.CONFLICT, "AUTH_003", "이미 사용 중인 이메일입니다."),
+    USERNAME_ALREADY_USED(HttpStatus.CONFLICT, "AUTH_003", "이미 사용 중인 닉네임입니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_004", "비밀번호 형식이 올바르지 않습니다."),
     INVALID_EMAIL(HttpStatus.NOT_FOUND, "AUTH_005", "존재하지 않는 이메일입니다."),
 


### PR DESCRIPTION
### Task
- Posts에 Content의 속성을 TEXT로 변경
- 닉네임이 겹칠 때 일어나는 예외처리에 있던 잘못된 메세지 수정